### PR TITLE
fix(widget.luau): tostring phase

### DIFF
--- a/src/client/apps/overview_scheduler/widget.luau
+++ b/src/client/apps/overview_scheduler/widget.luau
@@ -384,7 +384,7 @@ return function(props: props)
 					return pebble.accordion {
 						expanded = expanded,
 						set_expanded = expanded,
-						text = phase,
+						text = tostring(phase),
 						
 						pebble.container {
 							Size = UDim2.fromScale(1, 0),


### PR DESCRIPTION
There was an issue when i was using planck where it tried setting the text to a table (which was the phase) and it gave an error, this pull request will essentially just tostring phase, the following images shows the error before this and this fix working on the scheduler

Before fix when opening scheduler tab:
![image](https://github.com/user-attachments/assets/812c5686-6ada-4043-a885-71b7694fc0a1)

After fix:
![image](https://github.com/user-attachments/assets/b1763079-d7bb-4e5d-968d-a1b8ac671495)
