### PR TITLE
Fix incorrect destroy method name

### DIFF
--- a/src/server/systems/entity.luau
+++ b/src/server/systems/entity.luau
@@ -107,7 +107,9 @@ return function()
 			local world = world_data.world
 			local entity = inspect_data.entity
 
-			world:destroy(entity)
+			if world:contains(entity) then
+				world:destroy(entity)
+			end
 		end
 
 		for incoming, inspect_id, settings in update_inspect_settings:iter() do

--- a/src/server/systems/entity.luau
+++ b/src/server/systems/entity.luau
@@ -107,7 +107,7 @@ return function()
 			local world = world_data.world
 			local entity = inspect_data.entity
 
-			world:delete(entity)
+			world:destroy(entity)
 		end
 
 		for incoming, inspect_id, settings in update_inspect_settings:iter() do


### PR DESCRIPTION
Fixes a call to `world:delete` which with ECR should be `world:destroy`.