### PR TITLE
Fix error when adding tags to entities

### DIFF
--- a/src/server/systems/entity.luau
+++ b/src/server/systems/entity.luau
@@ -197,8 +197,8 @@ return function()
 				if data == nil then
 					world:remove(entity, entity_to_set)
 				elseif data == TAG then
-					-- tag is handled separately, as its still just "nil"
-					-- the difference is that entities used as tags arent allowed to store data
+					-- trying to use world:set with a tag will result in an error,
+					-- even if the data is nil, so instead we use world:add
 					world:add(entity, entity_to_set)
 				else
 					world:set(entity, entity_to_set, data)

--- a/src/server/systems/entity.luau
+++ b/src/server/systems/entity.luau
@@ -199,7 +199,7 @@ return function()
 				elseif data == TAG then
 					-- tag is handled separately, as its still just "nil"
 					-- the difference is that entities used as tags arent allowed to store data
-					world:set(entity, entity_to_set)
+					world:add(entity, entity_to_set)
 				else
 					world:set(entity, entity_to_set, data)
 				end


### PR DESCRIPTION
Jabby previously used `world:set` to add tags to entities, however it should use `world:add` instead.